### PR TITLE
add digestWithInitial 

### DIFF
--- a/src/Data/Digest/CRC.hs
+++ b/src/Data/Digest/CRC.hs
@@ -7,6 +7,7 @@
 module Data.Digest.CRC
     ( CRC(..)
     , digest
+    , digestWithInitial
     ) where
 
 
@@ -32,3 +33,6 @@ class CRC a where
 
 digest :: CRC a => ByteString -> a
 digest = updateDigest initCRC
+
+digestWithInitial :: CRC a => a -> ByteString -> a
+digestWithInitial = updateDigest


### PR DESCRIPTION
This PR exposes `updateDigest `under the name of  `digestWithInitial` so that CRC calculations with an initial value other than 0 are possible.
eg: 
```
λ> digestWithInitial (CRC16 0xFFFF) (pack [0x02, 0x07]) 
CRC16 {crc16 = 4673}) 
```